### PR TITLE
Update images page metadata, add specialty page links

### DIFF
--- a/app/[specialty]/functions.ts
+++ b/app/[specialty]/functions.ts
@@ -13,7 +13,7 @@ export function isSpecialty(specialty: unknown): specialty is Specialty {
  * Converts a specialty to its display text
  * (eg. inbound-marketing -> Inbound Marketing)
  */
-export function getSpecialtyText(specialty: Specialty) {
+export function getSpecialtyTitle(specialty: Specialty) {
   return specialty.split("-").map(capitalize).join(" ")
 }
 

--- a/app/[specialty]/images/[campaignId]/[projectId]/layout.tsx
+++ b/app/[specialty]/images/[campaignId]/[projectId]/layout.tsx
@@ -1,4 +1,4 @@
-import {getSpecialtyText, isSpecialty} from "@/app/[specialty]/functions"
+import {getSpecialtyTitle, isSpecialty} from "@/app/[specialty]/functions"
 import {Metadata} from "next"
 import {loadCampaignProjectImages} from "./functions"
 import {CampaignProjectImagesProps} from "./types"
@@ -18,7 +18,7 @@ export async function generateMetadata({
     })
     if (images.length > 0) {
       const metadata: Metadata = {
-        description: `${images[0].alt} from ${getSpecialtyText(specialty)}`,
+        description: `${images[0].alt} from ${getSpecialtyTitle(specialty)}`,
         openGraph: {
           images: [images[0]],
         },

--- a/app/[specialty]/images/[campaignId]/[projectId]/layout.tsx
+++ b/app/[specialty]/images/[campaignId]/[projectId]/layout.tsx
@@ -1,0 +1,37 @@
+import {getSpecialtyText, isSpecialty} from "@/app/[specialty]/functions"
+import {Metadata} from "next"
+import {loadCampaignProjectImages} from "./functions"
+import {CampaignProjectImagesProps} from "./types"
+
+/**
+ * Generates metadata which corresponds to the images
+ * from the selected specialty, campaign, and project
+ */
+export async function generateMetadata({
+  params: {campaignId, projectId, specialty},
+}: CampaignProjectImagesProps) {
+  if (isSpecialty(specialty)) {
+    const images = await loadCampaignProjectImages({
+      campaignId,
+      projectId,
+      specialty,
+    })
+    if (images.length > 0) {
+      const metadata: Metadata = {
+        description: `${images[0].alt} from ${getSpecialtyText(specialty)}`,
+        openGraph: {
+          images: [images[0]],
+        },
+      }
+      return metadata
+    }
+  }
+}
+
+export default function CampaignProjectImagesLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/app/[specialty]/images/[campaignId]/[projectId]/page.tsx
+++ b/app/[specialty]/images/[campaignId]/[projectId]/page.tsx
@@ -39,7 +39,7 @@ export default async function InboundMarketingImagePage({
   const route = `/${specialty}#${projectId}`
 
   return (
-    <main className="flex h-screen w-screen justify-center bg-gray-100 dark:bg-gray-700">
+    <main className="flex h-screen w-screen justify-center bg-gray-100 dark:bg-slate-900">
       {/* navigate to the specialty page if the user hits escape */}
       <NavigateOnKeyup keyName="Escape" {...{route}} />
       {/* X button, which also navigates to the specialty page */}

--- a/app/[specialty]/images/[campaignId]/[projectId]/page.tsx
+++ b/app/[specialty]/images/[campaignId]/[projectId]/page.tsx
@@ -4,19 +4,14 @@ import NavigateOnKeyup from "@/app/components/NavigateOnKeyup"
 import Image from "next/image"
 import {redirect} from "next/navigation"
 import {loadCampaignProjectImages} from "./functions"
+import {CampaignProjectImagesProps} from "./types"
 
 /**
  * Displays all images from a campaign project in a scrollable gallery
  */
-export default async function InboundMarketingImagePage({
+export default async function CampaignProjectImagesPage({
   params: {campaignId, projectId, specialty},
-}: {
-  params: {
-    campaignId: string
-    projectId: string
-    specialty: string
-  }
-}) {
+}: CampaignProjectImagesProps) {
   /* redirect home if the specialty is invalid */
   if (!isSpecialty(specialty)) {
     redirect("/")

--- a/app/[specialty]/images/[campaignId]/[projectId]/types.ts
+++ b/app/[specialty]/images/[campaignId]/[projectId]/types.ts
@@ -10,3 +10,14 @@ export type CampaignProjectImagesResponse = Array<{
     images: Array<DatoImage>
   }>
 }>
+
+/**
+ * The props which can be accessed from within this module
+ */
+export type CampaignProjectImagesProps = {
+  params: {
+    campaignId: string
+    projectId: string
+    specialty: string
+  }
+}

--- a/app/[specialty]/layout.tsx
+++ b/app/[specialty]/layout.tsx
@@ -1,5 +1,5 @@
 import {Metadata} from "next"
-import {getCampaigns, getSpecialtyText, isSpecialty} from "./functions"
+import {getCampaigns, getSpecialtyTitle, isSpecialty} from "./functions"
 import {SpecialtyProps} from "./types"
 
 /**
@@ -7,7 +7,7 @@ import {SpecialtyProps} from "./types"
  */
 export async function generateMetadata({params: {specialty}}: SpecialtyProps) {
   if (isSpecialty(specialty)) {
-    const title = getSpecialtyText(specialty)
+    const title = getSpecialtyTitle(specialty)
     const campaigns = await getCampaigns(specialty)
     const metadata: Metadata = {
       description: `${title} campaigns led by Andrea Alcala Vasquez, including ${campaigns[0].title}`,

--- a/app/[specialty]/page.tsx
+++ b/app/[specialty]/page.tsx
@@ -3,7 +3,8 @@ import {redirect} from "next/navigation"
 import React from "react"
 import ContentWrapper from "../components/ContentWrapper"
 import CoreLink from "../components/CoreLink"
-import {getCampaigns, isSpecialty} from "./functions"
+import {specialties} from "./constants"
+import {getCampaigns, getSpecialtyText, isSpecialty} from "./functions"
 import {SpecialtyProps} from "./types"
 
 /**
@@ -108,6 +109,15 @@ export default async function SpecialtyPage({
             </div>
           </div>
         ))}
+        <div className="flex flex-wrap justify-center gap-6 px-6">
+          {specialties
+            .filter(s => s !== specialty)
+            .map(slug => (
+              <CoreLink key={slug} href={`/${slug}`} variant="underlined">
+                {getSpecialtyText(slug)}
+              </CoreLink>
+            ))}
+        </div>
         <CoreLink className="underline" href={`/${specialty}#top-of-page`}>
           Scroll to top
         </CoreLink>

--- a/app/[specialty]/page.tsx
+++ b/app/[specialty]/page.tsx
@@ -4,7 +4,7 @@ import React from "react"
 import ContentWrapper from "../components/ContentWrapper"
 import CoreLink from "../components/CoreLink"
 import {specialties} from "./constants"
-import {getCampaigns, getSpecialtyText, isSpecialty} from "./functions"
+import {getCampaigns, getSpecialtyTitle, isSpecialty} from "./functions"
 import {SpecialtyProps} from "./types"
 
 /**
@@ -114,7 +114,7 @@ export default async function SpecialtyPage({
             .filter(s => s !== specialty)
             .map(slug => (
               <CoreLink key={slug} href={`/${slug}`} variant="underlined">
-                {getSpecialtyText(slug)}
+                {getSpecialtyTitle(slug)}
               </CoreLink>
             ))}
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
 import {specialties} from "./[specialty]/constants"
-import {getSpecialtyText} from "./[specialty]/functions"
+import {getSpecialtyTitle} from "./[specialty]/functions"
 import ContentWrapper from "./components/ContentWrapper"
 import CoreLink from "./components/CoreLink"
 
@@ -26,7 +26,7 @@ export default function HomePage() {
               href={specialty}
               key={specialty}
             >
-              {getSpecialtyText(specialty)}
+              {getSpecialtyTitle(specialty)}
             </CoreLink>
           ))}
         </div>


### PR DESCRIPTION
# Description

 Improved the specificity of the metadata and updated the background color of the dynamic specialty campaign project image gallery pages.

At the bottom of each specialty page, just above the scroll to top button, we will now display styled links to each of the other two specialty pages.

Also updated the name of `getSpecialtyTitle` to make its purpose more clear.