### PR TITLE
Load static data at build time

### DIFF
--- a/app/[specialty]/functions.ts
+++ b/app/[specialty]/functions.ts
@@ -28,7 +28,7 @@ export function getCampaignKey(specialty: Specialty) {
 /**
  * Loads all campaigns related to a specialty
  */
-export function getCampaigns(specialty: Specialty) {
+export function loadCampaigns(specialty: Specialty) {
   const campaignKey = getCampaignKey(specialty)
   return makeDatoRequest<CampaignsResponse>({
     query: `

--- a/app/[specialty]/images/[campaignId]/[projectId]/layout.tsx
+++ b/app/[specialty]/images/[campaignId]/[projectId]/layout.tsx
@@ -16,7 +16,7 @@ export async function generateMetadata({
       projectId,
       specialty,
     })
-    if (images.length > 0) {
+    if (images.length > 1) {
       const metadata: Metadata = {
         description: `${images[0].alt} from ${getSpecialtyTitle(specialty)}`,
         openGraph: {

--- a/app/[specialty]/images/[campaignId]/[projectId]/page.tsx
+++ b/app/[specialty]/images/[campaignId]/[projectId]/page.tsx
@@ -24,8 +24,8 @@ export default async function CampaignProjectImagesPage({
     specialty,
   })
 
-  /* show the not found page if there are no images */
-  if (images.length === 0) {
+  /* show the not found page if there are less than two images */
+  if (images.length < 2) {
     notFound()
   }
 

--- a/app/[specialty]/images/[campaignId]/[projectId]/page.tsx
+++ b/app/[specialty]/images/[campaignId]/[projectId]/page.tsx
@@ -1,10 +1,30 @@
-import {isSpecialty} from "@/app/[specialty]/functions"
+import {specialties} from "@/app/[specialty]/constants"
+import {isSpecialty, loadCampaigns} from "@/app/[specialty]/functions"
 import CoreLink from "@/app/components/CoreLink"
 import NavigateOnKeyup from "@/app/components/NavigateOnKeyup"
 import Image from "next/image"
 import {notFound} from "next/navigation"
 import {loadCampaignProjectImages} from "./functions"
 import {CampaignProjectImagesProps} from "./types"
+
+export async function generateStaticParams() {
+  const params: Array<CampaignProjectImagesProps["params"]> = []
+  for (const specialty of specialties) {
+    const campaigns = await loadCampaigns(specialty)
+    for (const campaign of campaigns) {
+      for (const project of campaign.projects) {
+        if (project.images.length > 1) {
+          params.push({
+            campaignId: campaign.id,
+            projectId: project.id,
+            specialty,
+          })
+        }
+      }
+    }
+  }
+  return params
+}
 
 /**
  * Displays all images from a campaign project in a scrollable gallery

--- a/app/[specialty]/images/[campaignId]/[projectId]/page.tsx
+++ b/app/[specialty]/images/[campaignId]/[projectId]/page.tsx
@@ -7,6 +7,9 @@ import {notFound} from "next/navigation"
 import {loadCampaignProjectImages} from "./functions"
 import {CampaignProjectImagesProps} from "./types"
 
+/**
+ * Loads all image galleries at build time
+ */
 export async function generateStaticParams() {
   const params: Array<CampaignProjectImagesProps["params"]> = []
   for (const specialty of specialties) {

--- a/app/[specialty]/layout.tsx
+++ b/app/[specialty]/layout.tsx
@@ -1,5 +1,5 @@
 import {Metadata} from "next"
-import {getCampaigns, getSpecialtyTitle, isSpecialty} from "./functions"
+import {getSpecialtyTitle, isSpecialty, loadCampaigns} from "./functions"
 import {SpecialtyProps} from "./types"
 
 /**
@@ -8,7 +8,7 @@ import {SpecialtyProps} from "./types"
 export async function generateMetadata({params: {specialty}}: SpecialtyProps) {
   if (isSpecialty(specialty)) {
     const title = getSpecialtyTitle(specialty)
-    const campaigns = await getCampaigns(specialty)
+    const campaigns = await loadCampaigns(specialty)
     const metadata: Metadata = {
       description: `${title} campaigns led by Andrea Alcala Vasquez, including ${campaigns[0].title}`,
       keywords: [title, ...campaigns.map(c => c.title)],

--- a/app/[specialty]/page.tsx
+++ b/app/[specialty]/page.tsx
@@ -7,6 +7,10 @@ import {specialties} from "./constants"
 import {getCampaigns, getSpecialtyTitle, isSpecialty} from "./functions"
 import {SpecialtyProps} from "./types"
 
+export function generateStaticParams() {
+  return specialties.map(specialty => ({specialty}))
+}
+
 /**
  * Dynamic page which displays all campaigns related to a specialty
  */

--- a/app/[specialty]/page.tsx
+++ b/app/[specialty]/page.tsx
@@ -4,7 +4,7 @@ import React from "react"
 import ContentWrapper from "../components/ContentWrapper"
 import CoreLink from "../components/CoreLink"
 import {specialties} from "./constants"
-import {getCampaigns, getSpecialtyTitle, isSpecialty} from "./functions"
+import {getSpecialtyTitle, isSpecialty, loadCampaigns} from "./functions"
 import {SpecialtyProps} from "./types"
 
 export function generateStaticParams() {
@@ -23,7 +23,7 @@ export default async function SpecialtyPage({
   }
 
   /* load all campaigns for this specialty */
-  const campaigns = await getCampaigns(specialty)
+  const campaigns = await loadCampaigns(specialty)
 
   return (
     <ContentWrapper>

--- a/app/[specialty]/page.tsx
+++ b/app/[specialty]/page.tsx
@@ -7,6 +7,9 @@ import {specialties} from "./constants"
 import {getSpecialtyTitle, isSpecialty, loadCampaigns} from "./functions"
 import {SpecialtyProps} from "./types"
 
+/**
+ * Loads the content for each specialty at build time
+ */
 export function generateStaticParams() {
   return specialties.map(specialty => ({specialty}))
 }

--- a/app/about/layout.tsx
+++ b/app/about/layout.tsx
@@ -16,10 +16,6 @@ export async function generateMetadata() {
   return metadata
 }
 
-export default function SpecialtyLayout({
-  children,
-}: {
-  children: React.ReactNode
-}) {
+export default function AboutLayout({children}: {children: React.ReactNode}) {
   return children
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,6 @@
 import classNames from "classnames"
 import type {Metadata} from "next"
 import {Mulish} from "next/font/google"
-import {specialties} from "./[specialty]/constants"
-import {getCampaigns} from "./[specialty]/functions"
-import {loadCampaignProjectImages} from "./[specialty]/images/[campaignId]/[projectId]/functions"
-import {loadAboutPageData} from "./about/functions"
 import "./globals.css"
 
 /* we will use this font globally by default */
@@ -47,8 +43,6 @@ export const metadata: Metadata = {
  * Base layout which applies globally
  */
 export default function RootLayout({children}: {children: React.ReactNode}) {
-  loadStaticData()
-
   return (
     <html lang="en">
       <body
@@ -61,20 +55,4 @@ export default function RootLayout({children}: {children: React.ReactNode}) {
       </body>
     </html>
   )
-}
-
-async function loadStaticData() {
-  loadAboutPageData()
-  for (const specialty of specialties) {
-    const campaigns = await getCampaigns(specialty)
-    for (const campaign of campaigns) {
-      for (const project of campaign.projects) {
-        loadCampaignProjectImages({
-          campaignId: campaign.id,
-          projectId: project.id,
-          specialty,
-        })
-      }
-    }
-  }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,10 @@
 import classNames from "classnames"
 import type {Metadata} from "next"
 import {Mulish} from "next/font/google"
+import {specialties} from "./[specialty]/constants"
+import {getCampaigns} from "./[specialty]/functions"
+import {loadCampaignProjectImages} from "./[specialty]/images/[campaignId]/[projectId]/functions"
+import {loadAboutPageData} from "./about/functions"
 import "./globals.css"
 
 /* we will use this font globally by default */
@@ -43,6 +47,8 @@ export const metadata: Metadata = {
  * Base layout which applies globally
  */
 export default function RootLayout({children}: {children: React.ReactNode}) {
+  loadStaticData()
+
   return (
     <html lang="en">
       <body
@@ -55,4 +61,20 @@ export default function RootLayout({children}: {children: React.ReactNode}) {
       </body>
     </html>
   )
+}
+
+async function loadStaticData() {
+  loadAboutPageData()
+  for (const specialty of specialties) {
+    const campaigns = await getCampaigns(specialty)
+    for (const campaign of campaigns) {
+      for (const project of campaign.projects) {
+        loadCampaignProjectImages({
+          campaignId: campaign.id,
+          projectId: project.id,
+          specialty,
+        })
+      }
+    }
+  }
 }


### PR DESCRIPTION
# Description

By incorporating `getStaticParams` into our dynamic routes we are able to significantly improve load times by generating the static pages at build time instead of run time.

I also included a bit of minor refactoring.