### PR TITLE
Ensure first image of specialty gets priority prop

### DIFF
--- a/app/[specialty]/page.tsx
+++ b/app/[specialty]/page.tsx
@@ -28,6 +28,11 @@ export default async function SpecialtyPage({
   /* load all campaigns for this specialty */
   const campaigns = await loadCampaigns(specialty)
 
+  /* find the ID of the first project (if any) which has one or more images */
+  const firstImageProjectId = campaigns
+    .find(c => c.projects.some(p => p.images.length > 0))
+    ?.projects.find(p => p.images.length > 0)?.id
+
   return (
     <ContentWrapper>
       <main className="flex flex-col items-center justify-center gap-20 px-6 text-center">
@@ -41,16 +46,7 @@ export default async function SpecialtyPage({
             </h1>
             <div className="flex max-w-screen-sm flex-col gap-6">
               {campaign.projects.map(
-                ({
-                  id,
-                  images,
-                  index,
-                  linkUrl,
-                  linkText,
-                  subtitle,
-                  text,
-                  title,
-                }) => (
+                ({id, images, linkText, linkUrl, subtitle, text, title}) => (
                   <React.Fragment key={id}>
                     {title && (
                       <h2 className="text-lg font-bold sm:text-xl lg:text-2xl">
@@ -97,7 +93,9 @@ export default async function SpecialtyPage({
                         <Image
                           alt={images[0].alt}
                           height={images[0].height}
-                          priority={index === 0}
+                          /* the image needs the priority prop only if this is
+                          the first project which contains one or more images */
+                          priority={id === firstImageProjectId}
                           src={images[0].url}
                           title={images[0].title || images[0].alt}
                           width={images[0].width}


### PR DESCRIPTION
In order to quickly load images which are above the fold, we pass a prop called `priority` to Next's Image component. However, the previous logic for determining whether an image within a specialty page should receive this prop was flawed in a number of ways:

1. If there were multiple campaigns, the first image in the first project in each campaign (if there were any images) would receive the prop, whereas it should only have been passed to the first image in the first campaign
2. If the first project in a campaign did not include any images (as is the case within "event-planning"), none of the images would receive the prop
3. If there was no project with an index of 0 (again, this is the case within "event-planning" - the first project's index is 1), none of the images would receive the prop. This is a data issue but still worth accounting for

The new logic finds the first project within the specialty which includes at least one image, and relies on this ID instead of an arbitrary index. This ensures that we correctly identify the first image.

Here is the difference in performance when loading the first image in "event-planning" in incognito mode with cacheing disabled and fast 3G throttling:

**Previous:**
<img width="151" alt="Screen Shot 2023-11-22 at 5 55 17 PM" src="https://github.com/alcalandrea/alcalandrea.com/assets/51540371/36aa4d73-70c3-4a30-9620-72bb6d99de7f">

**Updated:**
<img width="171" alt="Screen Shot 2023-11-22 at 5 54 13 PM" src="https://github.com/alcalandrea/alcalandrea.com/assets/51540371/38afc2ca-493a-4372-a9e9-bbfe6fcc9d6f">